### PR TITLE
Failsafe for contig id list

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.2.1
+    0.2.2
 
 owners:
     [scanon,jayrbolton]

--- a/lib/AssemblyAPI/AssemblyAPIImpl.py
+++ b/lib/AssemblyAPI/AssemblyAPIImpl.py
@@ -299,7 +299,7 @@ class AssemblyAPI:
         # return variables are: returnVal
         #BEGIN get_contig_lengths
         ws = Workspace(self.workspaceURL, token=ctx['token'])
-        returnVal=Utils.get_contig_lengths(ws, ref, contig_id_list)
+        returnVal=Utils.get_contig_lengths(ws, ref, contig_id_list or [])
         #END get_contig_lengths
 
         # At some point might do deeper type checking...
@@ -322,7 +322,7 @@ class AssemblyAPI:
         # return variables are: returnVal
         #BEGIN get_contig_gc_content
         ws = Workspace(self.workspaceURL, token=ctx['token'])
-        returnVal=Utils.get_contig_gc_content(ws, ref, contig_id_list)
+        returnVal=Utils.get_contig_gc_content(ws, ref, contig_id_list or [])
         #END get_contig_gc_content
 
         # At some point might do deeper type checking...

--- a/test/AssemblyAPI_server_test.py
+++ b/test/AssemblyAPI_server_test.py
@@ -242,6 +242,11 @@ class AssemblyAPITest(unittest.TestCase):
         ret = self.getImpl().get_contig_lengths(self.ctx, self.obj_ref, self.contigs)
         self.assertEqual(ret[0], {'NZ_ALQT01000016': 53554})
 
+    def test_get_contig_lengths_null_contigs(self):
+        """Test that it doesn't fail to pass None for the contig id list."""
+        ret = self.getImpl().get_contig_lengths(self.ctx, self.obj_ref, None)
+        self.assertEqual(ret[0], {})
+
     def test_get_contig_gc_content(self):
         ret = self.getImpl().get_contig_gc_content(self.ctx, self.obj_ref, self.contigs)
         self.assertEqual(ret[0], {'NZ_ALQT01000016': 0.35366172461440787})


### PR DESCRIPTION
Related ticket: https://kbase-jira.atlassian.net/browse/PUBLIC-729

This is not a bugfix for the underlying problem, but might allow the landing page to at least render instead of all-out crashing.